### PR TITLE
Fix a crash while renaming the downloaded file - #7

### DIFF
--- a/app.js
+++ b/app.js
@@ -359,8 +359,9 @@ Bluebird.coroutine(function*(emailAddress, password, twoFactorCode, restoreIndex
     streams.showStats();
     console.log("Download done, moving file...");
 
-    yield fileStream.endAsync();
+    fileStream.end();
     yield fs.renameAsync(restoreTmpFilePath, restoreRealFilePath);
 
     console.log("Download complete!");
+    process.exit(0);
 })(process.argv[2], process.argv[3], process.argv[4], process.argv[5], process.argv[6], process.argv[7]).done();


### PR DESCRIPTION
This quick patch fixes a crash while renaming the final downloaded file mentioned in issue #7 .